### PR TITLE
Small bugfixes for setuptools and pyHexDump

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,8 +1,16 @@
+[metadata]
+name = flashcontainer
+version = 0.0.4
+
 [options]
 packages = find:
 package_dir =
     =src
 include_package_data = True
+
+[options.entry_points]
+console_scripts =
+    pargen = flashcontainer.pargen:pargen_cli
 
 [options.packages.find]
 where=src

--- a/src/flashcontainer/__main__.py
+++ b/src/flashcontainer/__main__.py
@@ -1,4 +1,7 @@
-from . import pargen
+from .pargen import pargen_cli
+
+def main():
+    pargen_cli()
 
 if __name__ == '__main__':
-    pargen()
+    main()

--- a/src/flashcontainer/pyhexdumpwriter.py
+++ b/src/flashcontainer/pyhexdumpwriter.py
@@ -40,14 +40,14 @@ class PyHexDumpWriter(DM.Walker):
     """Create configuration file for pyHexDump (see https://github.com/BlueAndi/pyHexDump) """
 
     _TYPE_MAPPING = {
-        DM.ParamType.uint32: ("u32le", "u32be"),
         DM.ParamType.uint8: ("u8", "u8"),
         DM.ParamType.uint16: ("u16le", "u16be"),
+        DM.ParamType.uint32: ("u32le", "u32be"),
         DM.ParamType.uint64: ("u64le", "u64be"),
-        DM.ParamType.int8: ("u8", "u8"),
-        DM.ParamType.int16: ("u16le", "u16be"),
-        DM.ParamType.int32: ("u32le", "u32be"),
-        DM.ParamType.int64: ("u64le", "u64be"),
+        DM.ParamType.int8: ("s8", "s8"),
+        DM.ParamType.int16: ("s16le", "s16be"),
+        DM.ParamType.int32: ("s32le", "s32be"),
+        DM.ParamType.int64: ("s64le", "s64be"),
         DM.ParamType.float32: ("float32le", "float32be"),
         DM.ParamType.float64: ("float64le", "float64be"),
         DM.ParamType.utf8: ("u8", "u8")


### PR DESCRIPTION
* Signed datatypes are generating unsigned datatypes for pyHexDump
* Installation via "python setup.py install" were generating wrong executables.
* Calling project via "python -m src.flashcontainer" failed.